### PR TITLE
Add configuration for github_changelog_generator

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,12 @@
+user=gary-kim
+project=saspes
+add_sections={"dependencies": {"labels": ["dependencies"], "prefix": "### Dependencies"}, "Added": {"labels": ["feature"], "prefix": "### Added"}}
+output=
+header_label=# SAS Powerschool Enhancement Suite Changelog
+enhancement_prefix=### Changed
+deprecated_prefix=### Deprecated
+removed_prefix=### Removed
+security_prefix=### Security
+bug_prefix=### Fixed
+add_pr_wo_labels=false
+issues=false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,12 +89,13 @@ For a new file, add this license header to the top of the file:
 
 1. Ensure that all CI tests pass on the latest commit.
 2. Update the version number with `npm version [major|minor|patch] --no-git` and update the version name manually in [package.json](package.json).
-3. Run `npm ci` to install all dependencies for building from [package-lock.json](package-lock.json).
-4. Update [CHANGELOG.md](CHANGELOG.md) with the update changelog for the new version.
-5. Make a new git commit and tag with `git commit -S`,  `git tag VERSION -a`, add the new version name as the annotation, then run `git push origin VERSION`.
-6. Run `npm run libraries` to generate third-party library attributions.
-7. Run `npm run clean`, `SASPES_OFFICIAL_RELEASE=true npm run webpack:build:firefox`, then `npm run package`. Upload the resulting package to [AMO](https://addons.mozilla.org/en-US/developers/addons) to have the extension signed. Upload the result into GitHub releases then update the update server to point to the new release.
-8. Run `npm run clean`, `SASPES_OFFICIAL_RELEASE=true npm run webpack:build:chromium`, then `npm run package`. Upload the resulting package to [CWS](https://chrome.google.com/webstore/developer/dashboard) to have the new version signed and released.
+3. Run [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator) with `--since-tag <LAST VERSION> --future-release <NEW VERSION>` and take the resulting generated changelog and adjust it to our changelog style. Add this to the [CHANGELOG.md](CHANGELOG.md) file and make a PR for the new version. Wait until this PR gets merged (unlike other PRs, this PR should be merged with `--ff-only` rather then a merge commit).
+4. Run `npm ci` to install all dependencies for building from [package-lock.json](package-lock.json).
+5. Update [CHANGELOG.md](CHANGELOG.md) with the update changelog for the new version.
+6. Make a new git commit and tag with `git commit -S`,  `git tag VERSION -a`, add the new version name as the annotation, then run `git push origin VERSION`.
+7. Run `npm run libraries` to generate third-party library attributions.
+8. Run `npm run clean`, `SASPES_OFFICIAL_RELEASE=true npm run webpack:build:firefox`, then `npm run package`. Upload the resulting package to [AMO](https://addons.mozilla.org/en-US/developers/addons) to have the extension signed. Upload the result into GitHub releases then update the update server to point to the new release.
+9. Run `npm run clean`, `SASPES_OFFICIAL_RELEASE=true npm run webpack:build:chromium`, then `npm run package`. Upload the resulting package to [CWS](https://chrome.google.com/webstore/developer/dashboard) to have the new version signed and released.
 
 ### Developer Certificate of Origin
 ```


### PR DESCRIPTION
To make making the changelog far easier, adding support for using the [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator) project. 