### PR TITLE
Add Missing Indicator on the Main Page and Classes for Course and Assignment

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,7 @@
 {
-    "presets": ["@babel/preset-env"]
+    "presets": ["@babel/preset-env"],
+    "plugins": [
+        ["@babel/plugin-proposal-class-properties", {"loose": true}],
+        ["@babel/plugin-transform-runtime", {"regenerator":  true}]
+    ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -326,6 +326,99 @@
         "semver": "^5.5.0"
       }
     },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.3.tgz",
+      "integrity": "sha512-qmp4pD7zeTxsv0JNecSBsEmG1ei2MqwJq4YQcK3ZWm/0t07QstWfvuV/vm3Qt5xNMFETn2SZqpMx2MQzbtq+KA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+          "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/helper-create-regexp-features-plugin": {
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.6.tgz",
@@ -583,9 +676,9 @@
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.8.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
-          "integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -1228,6 +1321,16 @@
         "@babel/plugin-syntax-async-generators": "^7.8.0"
       }
     },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
+      "integrity": "sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
     "@babel/plugin-proposal-dynamic-import": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
@@ -1734,6 +1837,18 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz",
+      "integrity": "sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
@@ -1783,16 +1898,6 @@
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3"
-      }
-    },
-    "@babel/polyfill": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.7.0.tgz",
-      "integrity": "sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/preset-env": {
@@ -1903,10 +2008,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
-      "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
-      "dev": true,
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -12306,6 +12410,11 @@
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -12784,8 +12893,7 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-      "dev": true
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -15020,6 +15128,16 @@
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
+    "v-tooltip": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/v-tooltip/-/v-tooltip-2.0.3.tgz",
+      "integrity": "sha512-KZZY3s+dcijzZmV2qoDH4rYmjMZ9YKGBVoUznZKQX0e3c2GjpJm3Sldzz8HHH2Ud87JqhZPB4+4gyKZ6m98cKQ==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "popper.js": "^1.16.0",
+        "vue-resize": "^0.4.5"
+      }
+    },
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
@@ -15110,6 +15228,11 @@
         "vue-style-loader": "^4.1.0"
       }
     },
+    "vue-resize": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.5.tgz",
+      "integrity": "sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg=="
+    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",
@@ -15198,6 +15321,25 @@
         "zip-dir": "1.0.2"
       },
       "dependencies": {
+        "@babel/polyfill": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.7.0.tgz",
+          "integrity": "sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.6.5",
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+          "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "homepage": "https://github.com/gary-kim/saspes#readme",
   "devDependencies": {
     "@babel/core": "^7.8.6",
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/register": "^7.8.6",
     "ava": "^3.3.0",
     "babel-loader": "^8.0.6",
@@ -63,10 +65,12 @@
   },
   "dependencies": {
     "@babel/preset-env": "^7.8.6",
+    "@babel/runtime": "^7.8.4",
     "babel-eslint": "^10.0.3",
     "get-in-range": "^0.2.4",
     "get-key-range": "^1.0.1",
-    "jquery": "^3.4.1"
+    "jquery": "^3.4.1",
+    "v-tooltip": "^2.0.3"
   },
   "webExt": {
     "sourceDir": "dist",

--- a/src/css/spse.css
+++ b/src/css/spse.css
@@ -17,5 +17,5 @@
 .tooltip.saspes  {
     cursor: default;
     position: relative;
-    display: inline-block;
+    display: inline-block !important;
 }

--- a/src/js/components/ClassGrade.vue
+++ b/src/js/components/ClassGrade.vue
@@ -1,0 +1,239 @@
+<!--
+ - @copyright Copyright (c) 2020 Gary Kim <gary@garykim.dev>
+ -
+ - @author Gary Kim <gary@garykim.dev>
+ -
+ - @license GNU AGPL version 3 only
+ -
+ - SAS Powerschool Enhancement Suite - A browser extension to improve the experience of SAS Powerschool.
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, version 3.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ -->
+
+<template>
+    <div>
+        <v-popover
+            :open="showPopover && assignmentsMissing.length > 0"
+            :delay="{ show: 350, hide: 0 }"
+            placement="bottom"
+            trigger="manual"
+        >
+            <div
+                @mouseenter="showPopover = true"
+                @mouseleave="showPopover = false"
+            >
+                <a
+                    class="bold"
+                    :href="course.link"
+                >
+                    {{ course.grade }}
+                    <template v-if="finalPercent">
+                        ({{ finalPercent.toFixed(2) }})
+                    </template>
+                </a>
+                <img
+                    v-if="assignmentsMissing.length > 0"
+                    id="missing-icon"
+                    src="/images/icon_missing.gif"
+                    :title="missingNumberMessage"
+                >
+            </div>
+            <template slot="popover">
+                <div v-if="assignmentsMissing.length > 0">
+                    <div class="section-title">
+                        Missing {{ assignmentsMissing.length }} Assignment{{ assignmentsMissing.length > 1 ? 's' : '' }}
+                    </div>
+                    <div class="section-content">
+                        <div
+                            v-for="assignment in assignmentsMissing"
+                            :key="assignment.order"
+                        >
+                            {{ assignment.name }}
+                        </div>
+                    </div>
+                </div>
+            </template>
+        </v-popover>
+    </div>
+</template>
+
+<script>
+import { extractFinalPercent, assignments } from "../helpers";
+import Course from "../models/Course";
+
+import { VPopover } from 'v-tooltip';
+import browser from 'webextension-polyfill';
+
+export default {
+    name: "ClassGrade",
+    components: {
+        VPopover,
+    },
+    props: {
+        course: {
+            type: Course,
+            required: true,
+        },
+        showMissing: {
+            type: Boolean,
+            default: true,
+        },
+    },
+    data () {
+        return {
+            finalPercent: this.course.finalPercent,
+            assignments: this.course.assignments,
+            showPopover: false,
+        };
+    },
+    computed: {
+        missingNumberMessage () {
+            return `Missing ${this.assignmentsMissing.length} assignment${(this.assignmentsMissing.length > 1) ? 's' : ''} for ${this.course.name}`;
+        },
+        assignmentsMissing () {
+            if (this.assignments) {
+                return this.assignments.filter(e => e.isMissing());
+            }
+            return [];
+        },
+    },
+    async mounted () {
+        if (!(await browser.storage.local.get({ percent_main_page: true })).percent_main_page) {
+            return;
+        }
+        const page = document.implementation.createHTMLDocument();
+        page.documentElement.innerHTML = await (await fetch(this.course.link, { credentials: "same-origin" })).text();
+        this.finalPercent = extractFinalPercent(page.querySelector('table.linkDescList').innerHTML) || "";
+        if (this.showMissing) {
+            this.assignments = assignments(page.querySelector('body'));
+        }
+    },
+};
+</script>
+
+<style lang="less" scoped>
+@header-color: #a3bfcc;
+
+#missing-icon {
+    padding: 3px 3px 0 3px;
+    margin: 0;
+}
+.section {
+    &-title {
+        font-weight: bold;
+        background: @header-color;
+        padding: 5px 5px 0 5px;
+        text-align: center;
+    }
+
+    &-content {
+        padding: 5px;
+    }
+}
+</style>
+
+<style lang="less">
+.tooltip {
+    @header-color: #a3bfcc;
+    display: block !important;
+    z-index: 10000;
+
+    .tooltip-arrow {
+        width: 0;
+        height: 0;
+        border-style: solid;
+        position: absolute;
+        margin: 5px;
+        border-color: black;
+        z-index: 1;
+    }
+
+    &[x-placement^="top"] {
+        margin-bottom: 5px;
+
+        .tooltip-arrow {
+            border-width: 5px 5px 0 5px;
+            border-left-color: transparent !important;
+            border-right-color: transparent !important;
+            border-bottom-color: transparent !important;
+            bottom: -5px;
+            left: calc(50% - 5px);
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+    }
+
+    &[x-placement^="bottom"] {
+        margin-top: 5px;
+
+        .tooltip-arrow {
+            border-width: 0 5px 5px 5px;
+            border-color: @header-color !important;
+            border-left-color: transparent !important;
+            border-right-color: transparent !important;
+            border-top-color: transparent !important;
+            top: -5px;
+            left: calc(50% - 5px);
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+    }
+
+    &[x-placement^="right"] {
+        margin-left: 5px;
+
+        .tooltip-arrow {
+            border-width: 5px 5px 5px 0;
+            border-left-color: transparent !important;
+            border-top-color: transparent !important;
+            border-bottom-color: transparent !important;
+            left: -5px;
+            top: calc(50% - 5px);
+            margin-left: 0;
+            margin-right: 0;
+        }
+    }
+
+    &[x-placement^="left"] {
+        margin-right: 5px;
+
+        .tooltip-arrow {
+            border-width: 5px 0 5px 5px;
+            border-top-color: transparent !important;
+            border-right-color: transparent !important;
+            border-bottom-color: transparent !important;
+            right: -5px;
+            top: calc(50% - 5px);
+            margin-left: 0;
+            margin-right: 0;
+        }
+    }
+
+    &.popover {
+
+        .popover-inner {
+            background: #f9f9f9;
+            color: black;
+            padding: 0 0 5px 0;
+            border-radius: 5px;
+            box-shadow: 0 5px 30px rgba(black, .3);
+            overflow: hidden;
+        }
+
+        .popover-arrow {
+            border-color: #f9f9f9;
+            z-index: 5000;
+        }
+    }
+}
+</style>

--- a/src/js/components/HypoGrades.vue
+++ b/src/js/components/HypoGrades.vue
@@ -91,11 +91,12 @@ export default {
         },
     },
     data: () => ({
+        // Due to an issue with Vue reactivity not working on Course instances, using a standard JS object instead
         courses: [
             {
-                name: "Course 1",
-                link: "/course",
-                grade: "B",
+                name: "",
+                link: "",
+                grade: "",
             },
         ],
         gradeOptions: [...avaliableGrades, ""],
@@ -121,7 +122,16 @@ export default {
             }
         },
         resetData () {
-            this.courses = JSON.parse(JSON.stringify(this.initialCourses));
+            const toSet = [];
+            for (let i = 0; i < this.initialCourses.length; i++) {
+                const curr = this.initialCourses[i];
+                toSet.push({
+                    name: curr.name,
+                    link: curr.link,
+                    grade: curr.grade,
+                });
+            }
+            this.courses = toSet;
         },
     },
 };

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -24,6 +24,8 @@
 
 'use strict';
 
+import Assignment from "./models/Assignment";
+
 const getKeyRange = require('get-key-range');
 
 const grade_gpa = {
@@ -94,7 +96,7 @@ function fpToGrade (finalPercent) {
 
 /**
  * Calculates the grade point average with the given courses.
- * @param {Object[]} courses The courses for which the overall grade point average should be calculated.
+ * @param {Course[]} courses The courses for which the overall grade point average should be calculated.
  * @returns {string} The grade point average to the hundredth place.
  */
 function calculate_gpa (courses) {
@@ -153,6 +155,25 @@ function extractFinalPercent (html) {
     return number;
 }
 
+/**
+ * Return Assignment instances for the given class page.
+ * @param {Element} node Root node element of the class page.
+ * @returns {Assignment[]} Assignments in this course
+ */
+function assignments (node) {
+    const tr = [];
+    // Find assignments table, get it's rows, take out the header and legend rows.
+    [...node.querySelector('table[align=center').querySelectorAll('tr')].slice(1, -1).forEach((e, i) => {
+        const curr = e.querySelectorAll('td');
+        const assignment = new Assignment(curr[2].innerText, curr[curr.length - 1].innerText, i);
+        if (e.querySelector('img[src="/images/icon_missing.gif"]')) {
+            assignment.addStatus(Assignment.statuses.MISSING);
+        }
+        tr.push(assignment);
+    });
+    return tr;
+}
+
 export {
     gradeToFP,
     grade_fp,
@@ -162,4 +183,5 @@ export {
     gradeToGPA,
     calculate_gpa,
     extractFinalPercent,
+    assignments,
 };

--- a/src/js/models/Assignment.js
+++ b/src/js/models/Assignment.js
@@ -1,0 +1,81 @@
+/**
+ *
+ * @copyright Copyright (c) 2020 Gary Kim <gary@garykim.dev>
+ *
+ * @author Gary Kim <gary@garykim.dev>
+ *
+ * @license GNU AGPL version 3 only
+ *
+ * SAS Powerschool Enhancement Suite - A browser extension to improve the experience of SAS Powerschool.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+export default class Assignment {
+    static statuses = {
+        MISSING: 2,
+    };
+
+    #name;
+    #grade;
+    #order;
+    #status;
+
+    /**
+     * Create new Assignment instance
+     *
+     * @param {String} name the name of the assignment
+     * @param {String} [grade] grade of the assignment
+     * @param {Number} [order] order of the assignment in the course
+     * @param {Number[]} [status] current statuses of the assignment
+     */
+    constructor (name, grade, order, status) {
+        this.#name = name;
+        this.#grade = grade;
+        this.#order = order;
+        this.#status = status || [];
+    }
+
+    get name () {
+        return this.#name;
+    }
+
+    get grade () {
+        return this.#grade;
+    }
+
+    get order () {
+        return this.#order;
+    }
+
+    set grade (g) {
+        this.#grade = g;
+    }
+
+    /**
+     * Add a status to the assignment
+     * @param {Number} status
+     */
+    addStatus (status) {
+        this.#status.push(status);
+    }
+
+    /**
+     * Is assignment missing?
+     * @returns {boolean}
+     */
+    isMissing () {
+        return this.#status.includes(Assignment.statuses.MISSING);
+    }
+}

--- a/src/js/models/Course.js
+++ b/src/js/models/Course.js
@@ -1,0 +1,80 @@
+/**
+ *
+ * @copyright Copyright (c) 2020 Gary Kim <gary@garykim.dev>
+ *
+ * @author Gary Kim <gary@garykim.dev>
+ *
+ * @license GNU AGPL version 3 only
+ *
+ * SAS Powerschool Enhancement Suite - A browser extension to improve the experience of SAS Powerschool.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+export default class Course {
+    #name;
+    #grade;
+    #finalPercent;
+    #link;
+    #assignments;
+
+    /**
+     * Create new course instance
+     *
+     * @param {String} name the name of the course
+     * @param {String} link link to the course page
+     * @param {String} [grade] current grade for the course
+     * @param {Number?} [finalPercent] current final percent of the course
+     * @param {Assignment[]} [assignments] number of missing assignments
+     */
+    constructor (name, link, grade, finalPercent, assignments) {
+        this.#name = name;
+        this.#link = link;
+        this.#grade = grade;
+        this.#finalPercent = finalPercent;
+        this.#assignments = assignments;
+    }
+
+    get name () {
+        return this.#name;
+    }
+
+    get link () {
+        return this.#link;
+    }
+
+    get grade () {
+        return this.#grade;
+    }
+
+    set grade (g) {
+        this.#grade = g;
+    }
+
+    get finalPercent () {
+        return this.#finalPercent;
+    }
+
+    set finalPercent (fp) {
+        this.#finalPercent = fp;
+    }
+
+    get assignments () {
+        return this.#assignments;
+    }
+
+    set assignments (assignments) {
+        this.#assignments = assignments;
+    }
+}

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -31,16 +31,14 @@ import { calculate_gpa, extractFinalPercent, gradeToGPA } from './helpers';
 
 // Vue Components
 import Vue from 'vue';
+import ClassGrade from './components/ClassGrade';
 import ExtensionInfo from './components/ExtensionInfo.vue';
 import HypoAssignment from './components/HypoAssignment.vue';
 import HypoGrades from './components/HypoGrades';
 
-let percent_main_page = true;
-browser.storage.local.get({ percent_main_page: true }).then(
-    function (returned) {
-        percent_main_page = returned.percent_main_page;
-    }, function () {},
-);
+// Used models
+import Course from './models/Course';
+
 main();
 function main () {
     // Button on options page
@@ -106,7 +104,12 @@ function main_page () {
             const $first_grade = $cells.eq(s1col).find('a[href^="scores.html"]');
             if ($first_grade.length === 1) {
                 if (gradeToGPA($first_grade.text()) !== -1) {
-                    fill_percent($first_grade, `https://powerschool.sas.edu.sg/guardian/${$first_grade.attr('href')}`, [0], 0);
+                    new (Vue.extend(ClassGrade))({
+                        propsData: {
+                            course: new Course("", `https://powerschool.sas.edu.sg/guardian/${$first_grade.attr('href')}`, $first_grade.text()),
+                            showMissing: false,
+                        },
+                    }).$mount($first_grade.get(0));
                 }
             }
         } else {
@@ -114,14 +117,13 @@ function main_page () {
         }
         if ($course.length === 1) {
             const temp = $course.parents().eq(1).children("td[align=left]").text().match(".*(?=Details)")[0];
-            courses.push({
-                name: temp.trim(),
-                grade: $course.text(),
-                link: $course.attr('href'),
-                fp: -1,
-            });
+            courses.push(new Course(temp.trim(), `https://powerschool.sas.edu.sg/guardian/${$course.attr('href')}`, $course.text()));
             if (gradeToGPA($course.text()) !== -1) {
-                fill_percent($course, "https://powerschool.sas.edu.sg/guardian/" + $course.attr('href'), courses[courses.length - 1], "fp");
+                new (Vue.extend(ClassGrade))({
+                    propsData: {
+                        course: courses[courses.length - 1],
+                    },
+                }).$mount($course.get(0));
             }
         }
     }
@@ -140,13 +142,10 @@ function main_page () {
                 if (element_list.length > 2) {
                     for (let i = 2; i < element_list.length; i++) {
                         const $prev_course = element_list[i];
-                        courses_first_semester.push({
-                            name: $prev_course.getElementsByTagName("td")[0].textContent.trim(),
-                            grade: $prev_course.getElementsByTagName("td")[1].textContent.trim(),
-                            link: $prev_course.getElementsByTagName("td")[2].getElementsByTagName("a")[0].href,
-                            fp: -1,
-
-                        });
+                        courses_first_semester.push(new Course($prev_course.getElementsByTagName("td")[0].textContent.trim(),
+                            $prev_course.getElementsByTagName("td")[2].getElementsByTagName("a")[0].href,
+                            $prev_course.getElementsByTagName("td")[1].textContent.trim(),
+                        ));
                     }
                     $("table[border='0'][cellpadding='3'][cellspacing='1'][width='100%']").prepend(`<tr><td align="center">Last Semester GPA (S1): ${calculate_gpa(courses_first_semester)}</td></tr>`);
                 }
@@ -186,25 +185,6 @@ function login_page () {
                 showInfo: result.showExtensionInfo,
             },
         }).$mount('#saspes-info');
-    });
-}
-function fill_percent ($fill_location, url_link, percents, pos_in_arr) {
-    if (!percent_main_page) {
-        return;
-    }
-
-    $.ajax({
-        url: url_link,
-    }).done(function (data) {
-        const final_percent = extractFinalPercent(data);
-        if (!final_percent) {
-            percents[pos_in_arr] = -1;
-            return;
-        }
-        $fill_location.append(` (${final_percent.toFixed(2)})`);
-        percents[pos_in_arr] = final_percent.toFixed(2);
-    }).fail(function () {
-        percents[pos_in_arr] = -1;
     });
 }
 

--- a/src/ui/options.html
+++ b/src/ui/options.html
@@ -8,7 +8,7 @@
     <form>
         <label><input type="checkbox" id="analytics" />Enable Analytics</label>
         <br />
-        <label><input type="checkbox" id="percent-mp" />Load final percent on overall grade page</label>
+        <label><input type="checkbox" id="percent-mp" />Load final percent and missing assignments on overall grade page (More network intensive)</label>
         <br />
         <!--<label><input type="checkbox" id="save-grades" />Save last seen grades (requires previous option to work)</label>-->
     </form>


### PR DESCRIPTION
Closes #103 

**This PR also includes a refactoring to use classes for `Course` and `Assignment`**

This adds a missing indicator on the main page so you can easily see if you have missing assignments for a course.

EDIT: Now, it also adds a tooltip that pops up when hovering over the grade that lists the missing assignments.

I was also thinking, should this come with some kind of toggle in case you don't want the indicators?

One more thing I was thinking of adding was storing how many assignments are missing so the user can acknowledge missing assignments so the indicator only shows up again if you are missing even more assignments. Not entirely sure how the UI or storage for that would work though.

It looks like this when you are missing an assignment:
![Screenshot from 2020-02-20 11-14-59](https://user-images.githubusercontent.com/47195730/74897575-7b97b980-53d2-11ea-8300-6723c27c4960.png)



