### PR TITLE
Fix an issue in HypoAssignment

### DIFF
--- a/src/js/components/HypoAssignment.vue
+++ b/src/js/components/HypoAssignment.vue
@@ -70,7 +70,7 @@ export default {
     }),
     computed: {
         hypo () {
-            const weight = getInRange(this.assignment.weight, 0, 100, true);
+            const weight = getInRange(this.assignment.weight, 0, 100, true) || 0;
             const new_fp = weight * 0.01 * gradeToFP(this.assignment.grade) + ((100 - weight) * 0.01 * this.currentFP);
             return {
                 fp: new_fp.toFixed(2),


### PR DESCRIPTION
Closes #139 

@DGET-Program you want to take a look?

Hypothetical Assignment will show a NaN if
there is no value in the percentage input.

This is a fix for that issue. If there is no
value in the percentage field, it will be treated
as a zero.

Signed-off-by: Gary Kim <gary@garykim.dev>