### PR TITLE
Remove clipboard read permission

### DIFF
--- a/src/manifest - chromium.json
+++ b/src/manifest - chromium.json
@@ -9,8 +9,7 @@
     "description": "Provides various enhancements for SAS Powerschool",
     "permissions": [
         "storage",
-        "clipboardWrite",
-        "clipboardRead"
+        "clipboardWrite"
     ],
     "icons": {
         "128": "icons/128.png"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,8 +8,7 @@
     "description": "Provides various enhancements for SAS Powerschool",
     "permissions": [
         "storage",
-        "clipboardWrite",
-        "clipboardRead"
+        "clipboardWrite"
     ],
     "applications": {
         "gecko": {


### PR DESCRIPTION
Turns out the copy id code is not actually using this at the moment.

That may be the reason that Google is not approving the extension.

Signed-off-by: Gary Kim <gary@garykim.dev>