### PR TITLE
Fixes cumulative GPA counting older version of semester

### DIFF
--- a/src/js/components/CumulativeGPA.vue
+++ b/src/js/components/CumulativeGPA.vue
@@ -151,7 +151,7 @@ export default {
                     el.innerHTML = data;
                     const current_term_history = el.getElementsByClassName("selected")[0].textContent.split(" - ")[0];
                     const tabs = el.getElementsByClassName("tabs")[0].getElementsByTagName("li");
-                    // Iterate until the end of tabs or until no longer at a high school semester, first value indicates whether the course list is the most recent set of courses
+                    // Iterate until the end of tabs or until no longer at a high school semester
                     for (let i = 0; i < tabs.length && /HS$/.test(tabs[i].innerText); i++) {
                         fetches.push(
                             fetch(tabs[i].getElementsByTagName("a")[0].href)
@@ -200,7 +200,7 @@ export default {
                                 }
                             }
                         }
-                        // Handles edge case where grade history page is updated before semester end
+                        // Handles edge case where grade history page is updated before semester end, removes the old value and counts the latest version of the current semester.
                         if (current_term_history === current_term && include_current_semester && current_term_grades.length === 2 && current_semester) {
                             all_courses.splice(all_courses.indexOf(current_term_grades[1]), 1);
                         } else if (current_term_history === current_term && include_current_semester && current_term_grades.length === 1 && current_semester === false) {

--- a/src/js/components/CumulativeGPA.vue
+++ b/src/js/components/CumulativeGPA.vue
@@ -151,7 +151,7 @@ export default {
                     el.innerHTML = data;
                     const current_term_history = el.getElementsByClassName("selected")[0].textContent.split(" - ")[0];
                     const tabs = el.getElementsByClassName("tabs")[0].getElementsByTagName("li");
-                    // Iterate until the end of tabs or until no longer at a high school semester
+                    // Iterate until the end of tabs or until no longer at a high school semester, first value indicates whether the course list is the most recent set of courses
                     for (let i = 0; i < tabs.length && /HS$/.test(tabs[i].innerText); i++) {
                         fetches.push(
                             fetch(tabs[i].getElementsByTagName("a")[0].href)
@@ -202,9 +202,9 @@ export default {
                         }
                         // Handles edge case where grade history page is updated before semester end
                         if (current_term_history === current_term && include_current_semester && current_term_grades.length === 2 && current_semester) {
-                            include_current_semester = false;
+                            all_courses.splice(all_courses.indexOf(current_term_grades[1]), 1);
                         } else if (current_term_history === current_term && include_current_semester && current_term_grades.length === 1 && current_semester === false) {
-                            include_current_semester = false;
+                            all_courses.splice(all_courses.indexOf(current_term_grades[0]), 1);
                         }
 
                         if (include_current_semester) {


### PR DESCRIPTION
Fixes #180

Signed-off-by: Suhas Hariharan <hariharan774531@sas.edu.sg>

This should fix the issue with the cumulative GPA calculation counting an older version of the current semester GPA.

Right now when there is a current semester that is in powerschool and in grade history it counts the older version, this should fix it so it counts the newer version instead.